### PR TITLE
issue #4 : Fix classloading issue found by Java-9 testing

### DIFF
--- a/src/test/java/org/gbif/utils/file/BomSafeInputStreamWrapperTest.java
+++ b/src/test/java/org/gbif/utils/file/BomSafeInputStreamWrapperTest.java
@@ -50,10 +50,10 @@ public class BomSafeInputStreamWrapperTest {
     for (String f : new String[]{"utf8","utf8bom","utf16le","utf16be"}) {
       String fn = "/sax/" + f + ".xml";
       System.out.println(fn);
-      InputStream is = ClassLoader.class.getResourceAsStream(fn);
+      InputStream is = getClass().getResourceAsStream(fn);
       p.parse(is, new DefaultHandler2());
 
-      is = new BOMInputStream(ClassLoader.class.getResourceAsStream(fn));
+      is = new BOMInputStream(getClass().getResourceAsStream(fn));
       p.parse(is, new DefaultHandler2());
     }
   }
@@ -62,8 +62,8 @@ public class BomSafeInputStreamWrapperTest {
   public void testUTF16Stream() throws Exception {
     // should be the exact same bytes
 
-    byte[] b1 = IOUtils.toByteArray(ClassLoader.class.getResourceAsStream("/sax/utf16le.xml"));
-    byte[] b2 = IOUtils.toByteArray(new BOMInputStream(ClassLoader.class.getResourceAsStream("/sax/utf16le.xml")));
+    byte[] b1 = IOUtils.toByteArray(getClass().getResourceAsStream("/sax/utf16le.xml"));
+    byte[] b2 = IOUtils.toByteArray(new BOMInputStream(getClass().getResourceAsStream("/sax/utf16le.xml")));
 
     assertEquals(b1.length, b2.length);
     int idx=0;


### PR DESCRIPTION
A full fix for the build to succeed under the current Java-9 (9-ea+171) also requires using the motherpom version using the changes in https://github.com/gbif/motherpom/pull/3 I didn't update the motherpom version used here to include those changes though.