### PR TITLE
Fix #7 : Shade guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,19 +18,21 @@
   <properties>
     <jdkLevel>1.8</jdkLevel>
 
-    <commons-compress.version>1.10</commons-compress.version>
-    <commons-lang.version>3.4</commons-lang.version>
-    <commons-io.version>2.4</commons-io.version>
-    <guava.version>18.0</guava.version>
+    <commons-compress.version>1.14</commons-compress.version>
+    <commons-lang.version>3.6</commons-lang.version>
+    <commons-io.version>2.5</commons-io.version>
     <owasp-java-html-sanitizer.version>20160924.1</owasp-java-html-sanitizer.version>
-    <commons-beanutils.version>1.9.2</commons-beanutils.version>
+    <commons-beanutils.version>1.9.3</commons-beanutils.version>
+
+    <!-- Guava will be shaded -->
+    <guava.version>23.0</guava.version>
 
     <!--Jackson libraries will be shaded-->
-    <jackson-csv.version>2.8.7</jackson-csv.version>
+    <jackson-csv.version>2.9.0</jackson-csv.version>
 
     <junit.version>4.12</junit.version>
-    <logback.version>1.1.5</logback.version>
-    <slf4j.version>1.7.16</slf4j.version>
+    <logback.version>1.2.3</logback.version>
+    <slf4j.version>1.7.25</slf4j.version>
   </properties>
 
   <scm>
@@ -77,12 +79,17 @@
               <include>com.fasterxml.jackson.core:jackson-databind</include>
               <include>com.fasterxml.jackson.core:jackson-annotations</include>
               <include>com.fasterxml.jackson.dataformat:jackson-dataformat-csv</include>
+              <include>com.google.guava:guava</include>
             </includes>
           </artifactSet>
           <relocations>
             <relocation>
               <pattern>com.fasterxml.jackson</pattern>
               <shadedPattern>org.gbif.common.shaded.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>org.gbif.common.shaded.com.google.common</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
Guava regularly bumps its major version and includes method removals in the process of doing so, which fits with Semantic Versioning, but which limits reuse of libraries that externally depend on it. This removes that obstacle by shading/removing Guava as an external dependency, so it can be upgraded locally without affecting others.

Also updates Jackson, which is already shaded, Apache Commons libraries (do not need shading as they have a much longer maintenance cycle), and Slf4J (Does not need shading as it has a very reputable history in terms of backwards compatibility). Logback is only used as a test dependency, so bumping to keep up with latest bug fixes, but no effect on downstream projects.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>